### PR TITLE
Add support for App Store Connect provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ on the train early.
   * `appPath` String - The absolute path to your `.app` file
   * `appleId` String - The username of your apple developer account
   * `appleIdPassword` String - The password for your apple developer account
+  * `ascProvider` String (optional) - Your [Team ID](https://developer.apple.com/account/#/membership) in App Store Connect. This is necessary if you are part of multiple teams
 
 #### Safety when using `appleIdPassword`
 
@@ -56,6 +57,7 @@ async function packageTask () {
     appPath,
     appleId,
     appleIdPassword,
+    ascProvider, // This parameter is optional
   });
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,15 @@ export interface NotarizeAppOptions {
   appBundleId: string;
 }
 
+export interface TransporterOptions {
+  ascProvider: string;
+}
+
 export interface NotarizeResult {
   uuid: string;
 }
 
-export type NotarizeStartOptions = NotarizeAppOptions & NotarizeCredentials;
+export type NotarizeStartOptions = NotarizeAppOptions & NotarizeCredentials & TransporterOptions;
 export type NotarizeWaitOptions = NotarizeResult & NotarizeCredentials;
 export type NotarizeStapleOptions = Pick<NotarizeAppOptions, 'appPath'>;
 export type NotarizeOptions = NotarizeStartOptions;
@@ -47,20 +51,26 @@ export async function startNotarize(opts: NotarizeStartOptions): Promise<Notariz
     }
     d('zip succeeded, attempting to upload to apple');
 
+    const notarizeStartOpts = [
+      'altool',
+      '--notarize-app',
+      '-f',
+      zipPath,
+      '--primary-bundle-id',
+      opts.appBundleId,
+      '-u',
+      makeSecret(opts.appleId),
+      '-p',
+      makeSecret(opts.appleIdPassword),
+    ];
+
+    if (opts.ascProvider !== '') {
+      notarizeStartOpts.push(...['-itc_provider', opts.ascProvider]);
+    }
+
     const result = await spawn(
       'xcrun',
-      [
-        'altool',
-        '--notarize-app',
-        '-f',
-        zipPath,
-        '--primary-bundle-id',
-        opts.appBundleId,
-        '-u',
-        makeSecret(opts.appleId),
-        '-p',
-        makeSecret(opts.appleIdPassword),
-      ],
+      notarizeStartOpts,
     );
     if (result.code !== 0) {
       throw new Error(`Failed to upload app to Apples notarization servers\n\n${result.output}`);
@@ -152,12 +162,14 @@ export async function notarize({
   appPath,
   appleId,
   appleIdPassword,
+  ascProvider = '',
 }: NotarizeOptions) {
   const { uuid } = await startNotarize({
     appBundleId,
     appPath,
     appleId,
     appleIdPassword,
+    ascProvider,
   });
   await waitForNotarize({ uuid, appleId, appleIdPassword });
   await stapleApp({ appPath });

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ export async function notarize({
   appPath,
   appleId,
   appleIdPassword,
-  ascProvider = '',
+  ascProvider,
 }: NotarizeOptions) {
   const { uuid } = await startNotarize({
     appBundleId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,12 +65,12 @@ export async function startNotarize(opts: NotarizeStartOptions): Promise<Notariz
     ];
 
     if (opts.ascProvider) {
-      notarizeStartOpts.push('-itc_provider', opts.ascProvider);
+      notarizeArgs.push('-itc_provider', opts.ascProvider);
     }
 
     const result = await spawn(
       'xcrun',
-      notarizeStartOpts,
+      notarizeArgs,
     );
     if (result.code !== 0) {
       throw new Error(`Failed to upload app to Apples notarization servers\n\n${result.output}`);


### PR DESCRIPTION
Adds support for Transporter's `-itc_provider` parameter (see [Transporter documentation](https://help.apple.com/itc/transporteruserguide/#/apdAa073cb45). This parameter is necessary for anyone who is part of multiple development teams in App Store Connect. If this isn't specified for a user with multiple teams, notarization will fail with this error:


> *** Error: Your Apple ID account is attached to other iTunes providers. You will need to specify which
provider you intend to submit content to by using the -itc_provider command. Please contact us if you have questions or need help. (1627)