### PR TITLE
fix: add sleep for apple api lag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,12 @@ export async function notarize({
     appleIdPassword,
     ascProvider,
   });
+  // Wait for apple API to initialize the status UUID
+  await delay(2000);
   await waitForNotarize({ uuid, appleId, appleIdPassword });
   await stapleApp({ appPath });
+}
+
+function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
#2 
Adding a few seconds of waiting time before making the first call to check the status seems to solve this issue. Please test yourself as well before merging. 